### PR TITLE
Fix line endings, change version to string and add cloudevent fields

### DIFF
--- a/Event.cs
+++ b/Event.cs
@@ -52,7 +52,13 @@ namespace Nuclio.Sdk
         public string Url { get; set; }
 
         [DataMember(Name = "version")]
-        public long Version { get; set; }
+        public string Version { get; set; }
+
+        [DataMember(Name = "type")]
+        public string Type { get; set; }
+
+        [DataMember(Name = "typeVersion")]
+        public string TypeVersion { get; set; }
 
         [DataMember(Name = "timestamp")]
         [JsonFormatter(typeof(UnixTimestampInt64DateTimeFormatter))]

--- a/tests/JsonTests.cs
+++ b/tests/JsonTests.cs
@@ -85,7 +85,7 @@ namespace tests
             eve.Trigger.Class = "testclass";
             eve.Trigger.Kind = "testkind";
             eve.Url = "http://localhost";
-            eve.Version = 1234;
+            eve.Version = "1234";
 
             var deserialized = NuclioSerializationHelpers<Event>.Deserialize(eventsString);
             Assert.IsNotNull(deserialized);


### PR DESCRIPTION
1. CloudEvents introduced the notion of a "version" field (string). This clashed with a "version" field which was numeric in the event
2. Added two CloudEvent fields (type and typeVersion)
3. Fixed line endings for one file