### PR TITLE
Update Context.cs and Unit Tests

### DIFF
--- a/Context.cs
+++ b/Context.cs
@@ -12,12 +12,19 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
+
 namespace Nuclio.Sdk
 {
     public class Context
     {
+        public string Name { get; set; }
+
         public Logger Logger { get; set; }
 
+        public bool IsInitialized { get; set; }
+
+        public System.Collections.Generic.Dictionary<string, object> UserData { get; set; }
 
         public Context()
         {

--- a/nuclio-sdk-dotnetcore.csproj
+++ b/nuclio-sdk-dotnetcore.csproj
@@ -1,14 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
   <DefaultItemExcludes>tests/**;$(DefaultItemExcludes)</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Utf8Json" Version="1.3.7"/>
-    <PackageReference Include="Utf8Json.ImmutableCollection" Version="1.3.7"/>
+    <Compile Remove="JsonTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Utf8Json" Version="1.3.7" />
+    <PackageReference Include="Utf8Json.ImmutableCollection" Version="1.3.7" />
   </ItemGroup>
 </Project>

--- a/tests/JsonTests.cs
+++ b/tests/JsonTests.cs
@@ -57,7 +57,7 @@ namespace tests
         [TestMethod]
         public void SerializeEvent()
         {
-            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":9223372036854775807,\"id\":\"123\",\"method\":\"testmethod\",\"path\":\"testpath\",\"url\":\"http://localhost\",\"version\":1234,\"timestamp\":1518771661,\"trigger\":{\"class\":\"testclass\",\"kind\":\"testkind\"}}";
+            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":9223372036854775807,\"id\":\"123\",\"method\":\"testmethod\",\"path\":\"testpath\",\"url\":\"http://localhost\",\"version\":\"1234\",\"type\":\"snowman\",\"typeVersion\":\"0.1.2\",\"timestamp\":1518771661,\"trigger\":{\"class\":\"testclass\",\"kind\":\"testkind\"}}";
             
             var eve = new Event();
             eve.SetBody("{\"key1\":\"value1\", \"key2\":\"value2\"}");
@@ -72,7 +72,9 @@ namespace tests
             eve.Trigger.Class = "testclass";
             eve.Trigger.Kind = "testkind";
             eve.Url = "http://localhost";
-            eve.Version = 1234;
+            eve.Version = "1234";
+            eve.Type = "snowman";
+            eve.TypeVersion = "0.1.2";
 
             var serialized = NuclioSerializationHelpers<Event>.Serialize(eve);
             Assert.IsFalse(string.IsNullOrEmpty(serialized));
@@ -82,7 +84,7 @@ namespace tests
         [TestMethod]
         public void DeserializeEvent()
         {
-            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":9223372036854775807,\"id\":\"123\",\"method\":\"testmethod\",\"path\":\"testpath\",\"url\":\"http://localhost\",\"version\":1234,\"timestamp\":1518771661,\"trigger\":{\"class\":\"testclass\",\"kind\":\"testkind\"}}";
+            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":9223372036854775807,\"id\":\"123\",\"method\":\"testmethod\",\"path\":\"testpath\",\"url\":\"http://localhost\",\"version\":\"1234\",\"type\":\"snowman\",\"typeVersion\":\"0.1.2\",\"timestamp\":1518771661,\"trigger\":{\"class\":\"testclass\",\"kind\":\"testkind\"}}";
             var bodyValue = "{\"key1\":\"value1\", \"key2\":\"value2\"}";
             var eve = new Event();
             eve.SetBody(bodyValue);
@@ -96,6 +98,8 @@ namespace tests
             eve.Timestamp = new System.DateTime(2018, 02, 16, 09, 01, 01, System.DateTimeKind.Utc);
             eve.Trigger.Class = "testclass";
             eve.Trigger.Kind = "testkind";
+            eve.Type = "snowman";
+            eve.TypeVersion = "0.1.2";
             eve.Url = "http://localhost";
             eve.Version = "1234";
 
@@ -107,7 +111,7 @@ namespace tests
          [TestMethod]
         public void SerializeMissingPropertiesEvent()
         {
-            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":0,\"id\":\"123\",\"method\":null,\"path\":null,\"url\":null,\"version\":0,\"timestamp\":-62135596800,\"trigger\":{\"class\":null,\"kind\":null}}";
+            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":0,\"id\":\"123\",\"method\":null,\"path\":null,\"url\":null,\"version\":null,\"type\":null,\"typeVersion\":null,\"timestamp\":-62135578800,\"trigger\":{\"class\":null,\"kind\":null}}";
 
             var eve = new Event();
             eve.SetBody("{\"key1\":\"value1\", \"key2\":\"value2\"}");
@@ -124,7 +128,7 @@ namespace tests
         [TestMethod]
         public void DeserializeMissingPropertiesEvent()
         {
-            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":0,\"id\":\"123\",\"method\":null,\"path\":null,\"url\":null,\"version\":0,\"timestamp\":-62135596800,\"trigger\":{\"class\":null,\"kind\":null}}";
+            var eventsString = "{\"body\":\"eyJrZXkxIjoidmFsdWUxIiwgImtleTIiOiJ2YWx1ZTIifQ==\",\"content-type\":\"plain/text\",\"headers\":{\"testkey\":\"testvalue\"},\"fields\":{\"testkey\":\"testvalue\"},\"size\":0,\"id\":\"123\",\"method\":null,\"path\":null,\"url\":null,\"version\":null,\"timestamp\":-62135596800,\"trigger\":{\"class\":null,\"kind\":null}}";
             var bodyValue = "{\"key1\":\"value1\", \"key2\":\"value2\"}";
             var eve = new Event();
             eve.SetBody(bodyValue);

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR is a prerequisite to a subsequent PR that will update the dotnet wrapper files in the main Nuclio project. The intent will to make the `Wrapper.cs` call `InitContext()` on a dotnet function container on the first invocation of the function.  

The changes in this PR include adding the `IsInitialized`, `Name`, and `UserData` properties to `Context.cs`.  In the `tests` project, the .NET Core project version was upgraded from 2.0 to 3.1 to match that of the sdk project. The uniit tests in `JsonTests.cs`  were modified to fix their failures due to mismatch in property types on the `Event` class.


