### PR TITLE
Revert "Bump dotnet to 9.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,3 @@ lint: build-test-image
 .PHONY: build-test-image
 build-test-image:
 	@docker build -f tests/Dockerfile -t nuclio-test .
-
-.PHONY: bump-dependencies
-bump-dependencies:
-	@echo "🔄 Ensuring dotnet-outdated is installed..."
-	dotnet tool restore || dotnet tool install --global dotnet-outdated-tool
-	@echo "📦 Bumping root-level dependencies..."
-	dotnet outdated --upgrade
-	@echo "🧪 Bumping test project dependencies..."
-	cd tests && dotnet outdated --upgrade
-

--- a/nuclio-sdk-dotnetcore.csproj
+++ b/nuclio-sdk-dotnetcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
 WORKDIR nuclio
 

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nuclio-sdk-dotnetcore.csproj" />


### PR DESCRIPTION
Reverts nuclio/nuclio-sdk-dotnetcore#18, until Nuclio handles changes as well.